### PR TITLE
census: bump EXPECTED for legitimate 2026-07 batch growth (G14)

### DIFF
--- a/scripts/build_correction_loci.py
+++ b/scripts/build_correction_loci.py
@@ -186,16 +186,16 @@ def parse_file(path):
     return rows, headers_seen, headers_with_pc
 
 
-EXPECTED = {  # census snapshot 2026-07-07 (memo §1) — update when new batches land
-    'files': 35,
-    'rows': 39540,
+EXPECTED = {  # census snapshot 2026-07-18 (G14 bump) — update when new batches land
+    'files': 37,
+    'rows': 39555,
     'headers': 39606,
-    'new': 39536,
+    'new': 39551,
     'del': 4,
     'ins': 0,
     'bor_bulk': 21990,
     'lrv_markhom_bulk': 8063,
-    'rows_without_pc': 9,  # 8 headerless stc + 1 `; None` ap record
+    'rows_without_pc': 24,  # 15 headerless ap90 + 8 stc + 1 `; None` ap record
 }
 
 


### PR DESCRIPTION
## Summary
- `EXPECTED` in `scripts/build_correction_loci.py` was pinned to the 2026-07-07 census snapshot (35 files / 39540 rows); two real batches landed since (batch_20260712 promotion + ap90/MW/SKD/STC audit-trail commits), drifting the live count to 37 files / 39555 rows and tripping `--selftest`.
- Verified the growth is legitimate via `git log` (new batch/audit-trail commits, not a parser bug) before bumping the constants.
- `rows_without_pc` moved 9→24; broken down by dict: 15 headerless ap90 + 8 stc + 1 `; None` ap record (was 8 stc + 1 ap).

## Test plan
- [x] `python scripts/build_correction_loci.py --selftest` passes clean

Closes GTD row G14 (Uprava GTD_NEXT_ACTIONS.md, Agent-Ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)