### PR TITLE
H864: bump G14 census EXPECTED for the ap90 batch_20260712 append

### DIFF
--- a/scripts/build_correction_loci.py
+++ b/scripts/build_correction_loci.py
@@ -186,16 +186,16 @@ def parse_file(path):
     return rows, headers_seen, headers_with_pc
 
 
-EXPECTED = {  # census snapshot 2026-07-07 (memo §1) — update when new batches land
-    'files': 35,
-    'rows': 39540,
+EXPECTED = {  # census snapshot 2026-07-14 (H864 goal-reverify) — update when new batches land
+    'files': 37,
+    'rows': 39555,
     'headers': 39606,
-    'new': 39536,
+    'new': 39551,
     'del': 4,
     'ins': 0,
     'bor_bulk': 21990,
     'lrv_markhom_bulk': 8063,
-    'rows_without_pc': 9,  # 8 headerless stc + 1 `; None` ap record
+    'rows_without_pc': 24,  # grew from 9 with the ap90 batch_20260712 append (commit 9122065)
 }
 
 


### PR DESCRIPTION
## Summary
- Recovers stranded work from H864 (14-07-2026, Sonnet 5 `claude-sonnet-5`): the fix was committed + pushed to this branch as part of that handoff's goal re-verification pass, but no PR was ever opened, so it never reached `main` and G14 stayed red.
- `EXPECTED` in `scripts/build_correction_loci.py` was pinned to the 2026-07-07 census snapshot (35 files / 39540 rows); the 12-07-2026 AP90 correction batch (commit 9122065) grew it to 37 files / 39555 rows, tripping `--selftest`.

## Test plan
- [x] `python scripts/build_correction_loci.py --selftest` passes clean

Supersedes/closes #307 (an independently-produced duplicate of this same fix, opened before this stranded branch was discovered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)