### PR TITLE
fix(security): CLI-only gate for app/testgit.php (H1523)

### DIFF
--- a/app/testgit.php
+++ b/app/testgit.php
@@ -1,5 +1,33 @@
 <?php
- $cmd = "sh gitupdate.sh";
- $s = shell_exec($cmd);
- echo ($s);
+/*
+  testgit.php — run gitupdate.sh (add / commit / push correction-form intake).
+
+  H1523 security: this used to be callable over plain HTTP with no auth:
+    $cmd = "sh gitupdate.sh"; shell_exec($cmd);
+  Anyone who could hit the URL could force a git commit+push of the app tree.
+  Restrict to CLI only (php app/testgit.php). Server maintainers who still
+  need a web hook should put an authenticated endpoint in front, not this file.
+*/
+if (PHP_SAPI !== 'cli') {
+  http_response_code(403);
+  header('Content-Type: text/plain; charset=utf-8');
+  echo "Forbidden: CLI only (php app/testgit.php)\n";
+  exit(1);
+}
+
+$cwd = __DIR__;
+$script = $cwd . DIRECTORY_SEPARATOR . 'gitupdate.sh';
+if (!is_file($script)) {
+  fwrite(STDERR, "gitupdate.sh not found in $cwd\n");
+  exit(1);
+}
+
+// Fixed path only — no user input. escapeshellarg for the path is defense-in-depth.
+$cmd = 'sh ' . escapeshellarg($script);
+$out = shell_exec($cmd);
+if ($out === null) {
+  fwrite(STDERR, "shell_exec failed for gitupdate.sh\n");
+  exit(1);
+}
+echo $out;
 ?>


### PR DESCRIPTION
## Summary
`app/testgit.php` ran unauthenticated:
```php
$cmd = "sh gitupdate.sh";
$s = shell_exec($cmd);
```
`gitupdate.sh` does `git add .` / commit / **push origin master**. Anyone who could hit the PHP URL could force a commit+push of the correction-form tree.

## Fix
1. Refuse non-CLI SAPI with HTTP 403 (`php app/testgit.php` still works for operators)
2. Resolve `gitupdate.sh` via `__DIR__` + `escapeshellarg` (fixed path only; no user input)

H1523 org bug-hunt.