### PR TITLE
census: bump EXPECTED for legitimate 2026-08 batch growth (G14, H2035)

### DIFF
--- a/scripts/build_correction_loci.py
+++ b/scripts/build_correction_loci.py
@@ -186,16 +186,16 @@ def parse_file(path):
     return rows, headers_seen, headers_with_pc
 
 
-EXPECTED = {  # census snapshot 2026-07-18 (G14 bump) — update when new batches land
-    'files': 37,
-    'rows': 39555,
+EXPECTED = {  # census snapshot 2026-08-03 (G14 bump, H2035) — update when new batches land
+    'files': 45,
+    'rows': 61430,
     'headers': 39606,
-    'new': 39551,
+    'new': 61372,
     'del': 4,
-    'ins': 0,
+    'ins': 54,
     'bor_bulk': 21990,
     'lrv_markhom_bulk': 8063,
-    'rows_without_pc': 24,  # 15 headerless ap90 + 8 stc + 1 `; None` ap record
+    'rows_without_pc': 21899,  # 1 ap + 18 ap90 + 21817 mw (batch_pending bulk) + 54 mw72 + 1 pwg + 8 stc
 }
 
 


### PR DESCRIPTION
## Summary
- `EXPECTED` in `scripts/build_correction_loci.py` was pinned to the 2026-07-18 census snapshot (37 files / 39555 rows, PR #307); `batch_pending/` landed since (H2086, AP90/MW/MW72/PWG staging) plus other already-committed batches not yet folded into the census, drifting the live count to 45 files / 61430 rows and tripping `--selftest`.
- Verified via `git log` that the growth is legitimate new batch/tooling commits, not a parser bug, before bumping the constants (matches the measured delta already logged in H2028/H2035).
- `rows_without_pc` moved 24→21899, dominated by 21817 headerless MW rows in the new `batch_pending` bulk change files (breakdown: 1 ap + 18 ap90 + 21817 mw + 54 mw72 + 1 pwg + 8 stc).

## Test plan
- [x] `python scripts/build_correction_loci.py --selftest` → `SELFTEST OK`

Closes GTD row G14 (Uprava GTD_NEXT_ACTIONS.md) via [H2035](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2035-Sonnet_csl-corrections_g14-census-expected-bump-pr_31.07.26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
