### PR TITLE
add the pre-push silent-revert guard + CRLF-in-blob gate (H2280/H2289/H2301)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Uprava pre-push guard — stale-base silent-revert block (Uprava#1516, H2280).
+#
+# git feeds pre-push one line per ref being pushed on stdin:
+#     <local ref> <local sha> <remote ref> <remote sha>
+# For each real (non-delete) update we ask scripts/pre_push_stale_base_check.py
+# whether the push would install our version of a file over an upstream change
+# that our commits never saw. That is the shape behind both incidents on #1516:
+# a clean fast-forward, green pre-commit hooks, and six files (29-07) then 19
+# line-level fixes (04-08) silently reverted.
+#
+# Deliberately a PRE-PUSH, not a pre-commit: the commit is local and cheap to
+# redo, the push is the point of no return where other sessions start reading it.
+# Also the only layer that binds Claude Code and Codex identically, since both
+# invoke real `git push` through this hooks path.
+#
+# Escape hatch (a deliberate revert is legitimate):
+#     ALLOW_STALE_BASE_PUSH=1 git push ...
+#
+# Install once per clone:  git config core.hooksPath .githooks
+
+set -uo pipefail
+
+TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+CHECKER="$TOPLEVEL/scripts/pre_push_stale_base_check.py"
+# Uprava keeps the census in tools/; cologne_batch_deploy ships it to the other
+# guarded repos as scripts/eol_census.py, beside the stale-base checker. Probe
+# both so ONE hook file is correct in every repo it is deployed to.
+EOL_CENSUS="$TOPLEVEL/tools/eol_census.py"
+[ -f "$EOL_CENSUS" ] || EOL_CENSUS="$TOPLEVEL/scripts/eol_census.py"
+
+remote_name="${1:-origin}"
+status=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Branch deletion: local sha is all zeros. Nothing of ours to install.
+    case "$local_sha" in
+        *[!0]*) ;;
+        *) continue ;;
+    esac
+
+    # New remote branch (remote sha all zeros): nothing upstream to revert.
+    case "$remote_sha" in
+        *[!0]*) ;;
+        *) continue ;;
+    esac
+
+    # BRANCHES ONLY. `git push origin <tag>` also comes through here, and a tag
+    # ref has no remote-tracking counterpart: `${remote_ref#refs/heads/}` leaves
+    # "refs/tags/vX.Y.Z" intact, so both checks below would resolve
+    # "origin/refs/tags/vX.Y.Z", fail to parse it, and report that as a defect.
+    # Caught the first time this hook met a `git push --force <tag>` (H2301) —
+    # a new tag slipped through only because the all-zeros remote_sha branch
+    # above short-circuits first, so the bug was invisible on the initial push.
+    # A guard that refuses correct pushes gets switched off, which is how the
+    # stale-base sibling above ended up WARN-only.
+    case "$remote_ref" in
+        refs/heads/*) ;;
+        *) continue ;;
+    esac
+
+    # Compare against the remote-tracking ref for the branch actually being
+    # updated — `git push origin HEAD:main` from a feature branch must check
+    # origin/main, not origin/<feature>.
+    short_remote="${remote_ref#refs/heads/}"
+    tracking="$remote_name/$short_remote"
+
+    # (1) stale-base silent-revert check — WARN-only, see the header.
+    if [ -z "${ALLOW_STALE_BASE_PUSH:-}" ] && [ -f "$CHECKER" ]; then
+        if ! python "$CHECKER" "$local_sha" "$tracking"; then
+            status=1
+        fi
+    fi
+
+    # (2) CRLF-in-blob gate (H2301). Unlike (1) this BLOCKS, because it has no
+    #     judgment call in it: a CR byte in a `text`-attributed, non-binary blob
+    #     is unambiguously wrong, cheap to fix before the push, and effectively
+    #     unfixable after — `git checkout` cannot repair a bad stored object, so
+    #     every later session sees the file as permanently dirty and the standard
+    #     remedy for that false loss-signal is to DISCARD (FINDINGS §299·§305·§313).
+    #     Three passes closed this class on a per-checkout `git ls-files --eol`
+    #     measurement that structurally cannot see a remote-side violation; this
+    #     reads the pushed BLOBS instead, scoped to the paths the push changes
+    #     (~2 s, against ~34 s for a whole-repo scan).
+    #     Escape hatch: ALLOW_CRLF_BLOB_PUSH=1 git push ...
+    if [ -z "${ALLOW_CRLF_BLOB_PUSH:-}" ] && [ -f "$EOL_CENSUS" ]; then
+        if ! python "$EOL_CENSUS" --repo "$TOPLEVEL" --ref "$local_sha" \
+                    --changed-since "$tracking"; then
+            echo "pre-push: BLOCKED — see above. Override: ALLOW_CRLF_BLOB_PUSH=1" >&2
+            status=1
+        fi
+    fi
+done
+
+exit "$status"

--- a/scripts/eol_census.py
+++ b/scripts/eol_census.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Repository-level EOL census — reads BLOBS from a ref, never the local index.
+
+Why this exists (H2301, residual of H2266 / FINDINGS §299 · §305 · §313):
+`git ls-files --eol` reports the *index of the checkout you run it in*. That is
+how H2266's session read "0 violations" while `origin/main` was carrying a
+fully-CRLF 906 KB `FINDINGS.md` — three separate passes closed this class on a
+per-checkout measurement that structurally cannot see a remote-side violation.
+
+So this checker asks git for the **blob bytes at a ref** (`git cat-file --batch`
+over `<ref>:<path>`) and counts CR **bytes**. It never consults the working tree
+or the index, and it is therefore valid run from any clone, any worktree, or CI.
+
+Measurement note, learned expensively during H2266: count CR **bytes**
+(`tr -cd '\\r' | wc -c`), never matching lines. `grep -c $'\\r'` gave a wrong
+answer on these files and nearly produced a wrong finding.
+
+Usage
+-----
+    python tools/eol_census.py                     # census origin/main
+    python tools/eol_census.py --ref HEAD          # census another ref
+    python tools/eol_census.py --history FINDINGS.md
+                                                   # forensic: per-commit CR
+                                                   # counts + author + subject,
+                                                   # to NAME a bad writer
+
+Exit codes: 0 clean · 1 violations found · 2 usage/environment error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
+
+
+def git_bytes(repo: Path, *args: str, stdin: bytes | None = None) -> bytes:
+    """Run git and return raw stdout bytes (blob content must not be decoded).
+
+    The org rule is `encoding='utf-8'` on output-capturing subprocess calls; this
+    one is a DELIBERATE exception. Decoding here would destroy the very bytes the
+    census measures — a CR byte must be counted in the blob, not in some decoded
+    approximation of it. Decoding happens explicitly, per call site, in git_text.
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        input=stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed ({proc.returncode}): "
+            f"{proc.stderr.decode('utf-8', 'replace').strip()}"
+        )
+    return proc.stdout
+
+
+def git_text(repo: Path, *args: str, stdin: bytes | None = None) -> str:
+    return git_bytes(repo, *args, stdin=stdin).decode("utf-8", "replace")
+
+
+def ls_tree_paths(repo: Path, ref: str) -> list[str]:
+    out = git_bytes(repo, "ls-tree", "-r", "-z", "--name-only", ref)
+    return [p.decode("utf-8", "surrogateescape") for p in out.split(b"\0") if p]
+
+
+def eol_attrs(repo: Path, paths: list[str]) -> dict[str, tuple[str, str]]:
+    """Map path -> (text, eol) as the working-tree .gitattributes assigns them.
+
+    `check-attr` consults the working-tree .gitattributes, which is the same file
+    the ref carries in every normal case; a divergence there is itself worth
+    seeing, so it is not worked around here.
+    """
+    if not paths:
+        return {}
+    stdin = b"\0".join(p.encode("utf-8", "surrogateescape") for p in paths) + b"\0"
+    out = git_bytes(repo, "check-attr", "--stdin", "-z", "text", "eol", stdin=stdin)
+    fields = out.split(b"\0")
+    attrs: dict[str, tuple[str, str]] = {}
+    # -z output is a flat NUL stream of (path, attr, value) triples, one triple
+    # per requested attribute per path.
+    for i in range(0, len(fields) - 2, 3):
+        raw_path, attr, value = fields[i], fields[i + 1], fields[i + 2]
+        path = raw_path.decode("utf-8", "surrogateescape")
+        text, eol = attrs.get(path, ("unspecified", "unspecified"))
+        if attr == b"text":
+            text = value.decode()
+        elif attr == b"eol":
+            eol = value.decode()
+        attrs[path] = (text, eol)
+    return attrs
+
+
+def cr_counts_multi(repo: Path, specs: list[tuple[str, str]]) -> dict[tuple[str, str], int]:
+    """CR bytes for each (ref, path) blob, STREAMED from one cat-file --batch.
+
+    Streamed, not buffered. The first version captured the whole `--batch` output
+    into one bytes object, which is fine for Uprava (~4 700 paths) and fatal at
+    org scale: `kosha` has 51 269 tracked files, so the capture tried to hold the
+    entire text content of the repository in memory at once and simply never
+    returned. A checker that hangs on the largest repo in the fleet is one nobody
+    can deploy, so this reads blob-by-blob and keeps at most one body live.
+
+    Returns -1 for paths git would treat as binary — see is_binary.
+    """
+    if not specs:
+        return {}
+
+    proc = subprocess.Popen(
+        ["git", "-C", str(repo), "cat-file", "--batch"],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+    )
+    counts: dict[tuple[str, str], int] = {}
+
+    def feed() -> None:
+        try:
+            for ref, path in specs:
+                proc.stdin.write(f"{ref}:{path}\n".encode("utf-8", "surrogateescape"))
+            proc.stdin.close()
+        except (BrokenPipeError, OSError):
+            pass  # reader side died; the read loop below reports the short stream
+
+    # git blocks writing its output once the pipe buffer fills, so the request
+    # stream has to be fed from another thread or the two sides deadlock — the
+    # classic subprocess pipe deadlock, and it bites at exactly the repo sizes
+    # that motivated the rewrite.
+    writer = threading.Thread(target=feed, daemon=True)
+    writer.start()
+
+    out = proc.stdout
+    for key in specs:
+        header = out.readline()
+        if not header:
+            break
+        parts = header.decode("utf-8", "replace").rstrip("\n").rsplit(" ", 2)
+        if len(parts) != 3 or parts[1] != "blob":
+            # "missing" / non-blob: git emits no body, so the stream stays aligned.
+            continue
+        size = int(parts[2])
+        body = out.read(size)
+        out.read(1)  # trailing newline after the body
+        counts[key] = -1 if is_binary(body) else body.count(b"\r")
+
+    writer.join(timeout=5)
+    proc.stdout.close()
+    proc.wait(timeout=30)
+    return counts
+
+
+def is_text_tracked(text: str) -> bool:
+    """Should git store this path's blob with LF endings?
+
+    Yes whenever the `text` attribute is set or auto-detected — `eol` is NOT the
+    selector. `eol` decides what the WORKING TREE gets on checkout; the blob is
+    LF either way. Selecting on `eol == "lf"` would silently exempt every
+    `eol=crlf` path (`*.cmd`, `*.bat`) from a check that still applies to them.
+    """
+    return text in ("set", "auto")
+
+
+def is_binary(body: bytes) -> bool:
+    """git's own heuristic: a NUL byte within the first 8000 bytes (convert.c).
+
+    This matters because `* text=auto eol=lf` ASSIGNS eol=lf to every path in the
+    repo, including .docx and .pyc — but `text=auto` makes git skip conversion
+    for content it detects as binary, so those CR bytes are correct and expected.
+    Flagging them would bury the one real violation under ~500 false positives,
+    which is how a census stops being read.
+    """
+    return b"\0" in body[:8000]
+
+
+def cr_candidates(repo: Path, ref: str) -> list[str]:
+    """Paths at `ref` whose blob contains ANY CR byte — found C-side by git grep.
+
+    The performance load-bearing step. Byte-counting every text blob in Python is
+    fine for a hub repo and unusable at fleet scale: `kosha` (51 269 files, 292 MB
+    of history) never finished, while this returns its single candidate in ~5 s.
+    git does the whole scan in C and hands back a shortlist; exact CR *byte* counts
+    are then taken only on that shortlist, so the precision that matters is kept.
+
+    `-I` applies git's own binary detection, the same rule the census uses for
+    content exemption, so the prefilter cannot hide a text file. `-F` with a
+    literal CR avoids depending on a PCRE-enabled git build.
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "grep", "-I", "-l", "-z", "-F", "\r", ref],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    # exit 1 == "no matches", which is the clean case, not an error
+    if proc.returncode not in (0, 1):
+        raise RuntimeError(
+            f"git grep failed ({proc.returncode}): "
+            f"{proc.stderr.decode('utf-8', 'replace').strip()}"
+        )
+    prefix = f"{ref}:".encode("utf-8", "surrogateescape")
+    out = []
+    for field in proc.stdout.split(b"\0"):
+        if not field:
+            continue
+        if field.startswith(prefix):
+            field = field[len(prefix):]
+        out.append(field.decode("utf-8", "surrogateescape"))
+    return out
+
+
+def cmd_census(repo: Path, ref: str, quiet: bool) -> int:
+    all_paths = ls_tree_paths(repo, ref)
+    attrs = eol_attrs(repo, all_paths)
+    text_paths = {p for p, (text, _eol) in attrs.items() if is_text_tracked(text)}
+
+    # Prefilter C-side, then byte-count only the candidates.
+    candidates = [p for p in cr_candidates(repo, ref) if p in text_paths]
+    counts = cr_counts_multi(repo, [(ref, p) for p in candidates])
+
+    bad: list[tuple[int, str]] = []
+    skipped_binary = 0
+    for (_ref, path), n in counts.items():
+        if n == -1:
+            skipped_binary += 1
+        elif n:
+            bad.append((n, path))
+    bad.sort(reverse=True)
+
+    print(f"eol census · ref={ref} · {len(text_paths)} text-attributed of {len(all_paths)} paths,"
+          f" read as BLOBS (not the index) · {len(candidates)} CR candidate(s) byte-counted"
+          + (f" · {skipped_binary} binary" if skipped_binary else ""))
+    if not bad:
+        print("OK — 0 CR bytes across every text-attributed path at this ref.")
+        return 0
+
+    print(f"VIOLATION — {len(bad)} path(s) carry CR bytes in the blob at {ref}:")
+    for n, p in bad:
+        text = attrs.get(p, ("?", "?"))[0]
+        print(f"  {n:>9,} CR  {p}  (text: {text})")
+    if not quiet:
+        print()
+        print("Fix (must land as a FAST-FORWARD, never a rebase — FINDINGS §305):")
+        print("  git add --renormalize -- <path> && git commit -m 'fix(eol): renormalize to LF'")
+    return 1
+
+
+def cmd_changed(repo: Path, ref: str, since: str, quiet: bool) -> int:
+    """Census only the paths `since..ref` touches — the push-gate mode.
+
+    A full-repo census is ~34 s here, which is too slow to sit in front of every
+    push; a push can only introduce a violation through a path it changes, so
+    checking that set is the same guarantee at a fraction of the cost. The full
+    scan stays available for CI and for catching blobs that arrived by some route
+    that never ran this hook.
+    """
+    out = git_bytes(repo, "diff", "--name-only", "-z", f"{since}...{ref}")
+    changed = [p.decode("utf-8", "surrogateescape") for p in out.split(b"\0") if p]
+    if not changed:
+        print(f"eol census · {since}..{ref} · no paths changed")
+        return 0
+
+    attrs = eol_attrs(repo, changed)
+    paths = [p for p, (text, _eol) in attrs.items() if is_text_tracked(text)]
+    counts = cr_counts_multi(repo, [(ref, p) for p in paths])
+    dirty_now = {p: n for (_r, p), n in counts.items() if n > 0}
+
+    # RATCHET, not a snapshot. A path that was ALREADY CRLF at `since` is
+    # pre-existing debris, not something this push introduced — blocking on it
+    # would hand a maintainer a refusal for a defect they did not create, which
+    # is the failure mode that got the stale-base guard demoted to WARN and that
+    # gates `changelog-dupe-guard` on a content check. Measured 06-08-2026:
+    # IndologyScholars carries 1 311 such paths, so without this the gate would
+    # be undeployable in exactly the repo that needs it most. Only a path that is
+    # clean-or-absent at `since` and CR-dirty at `ref` is this push's doing.
+    before = cr_counts_multi(repo, [(since, p) for p in dirty_now])
+    preexisting = {p for p in dirty_now if before.get((since, p), 0) > 0}
+    bad = sorted(((n, p) for p, n in dirty_now.items() if p not in preexisting), reverse=True)
+
+    print(f"eol census · {since}..{ref} · {len(changed)} changed path(s), "
+          f"{len(paths)} text-attributed, read as BLOBS (not the index)"
+          + (f" · {len(preexisting)} pre-existing CRLF path(s) ignored" if preexisting else ""))
+    if not bad:
+        print("OK — this push introduces no new CR bytes.")
+        if preexisting:
+            print(f"     ({len(preexisting)} touched path(s) were already CRLF before it — "
+                  f"pre-existing, not blocked; renormalize separately.)")
+        return 0
+
+    print(f"VIOLATION — {len(bad)} path(s) would NEWLY land CR bytes in the blob:")
+    for n, p in bad:
+        print(f"  {n:>9,} CR  {p}  (text: {attrs.get(p, ('?', '?'))[0]})")
+    if not quiet:
+        print()
+        print("A CRLF blob on an eol=lf path cannot be repaired by `git checkout` —")
+        print("the defect is in the stored object, and every later checkout reports")
+        print("the file as dirty forever (FINDINGS §299 · §305 · §313).")
+        print("Fix before pushing:")
+        print("  git add --renormalize -- <path> && git commit --amend --no-edit")
+    return 1
+
+
+def cmd_history(repo: Path, ref: str, path: str) -> int:
+    """Per-commit CR counts for one path — the forensic half.
+
+    A writer that stores CRLF blobs shows up as a run of non-zero rows; the
+    author/subject columns are what actually name it.
+    """
+    revs = git_text(repo, "rev-list", "--reverse", ref, "--", path).split()
+    if not revs:
+        print(f"no commits touch {path} at {ref}", file=sys.stderr)
+        return 2
+
+    # One cat-file process for every (rev, path) blob and one git log for every
+    # commit's metadata. The naive one-subprocess-per-commit shape took minutes
+    # on a 424-commit path, which is long enough that nobody runs the forensic.
+    counts = cr_counts_multi(repo, [(r, path) for r in revs])
+    meta = {}
+    log = git_text(
+        repo, "log", "--no-walk=unsorted", "--format=%H%x09%h%x09%ad%x09%an%x09%s",
+        "--date=format:%Y-%m-%d %H:%M", *revs, "--",
+    )
+    for line in log.splitlines():
+        parts = line.split("\t", 4)
+        if len(parts) == 5:
+            meta[parts[0]] = parts[1:]
+
+    print(f"eol history · {path} · {len(revs)} commits at {ref}")
+    print(f"{'commit':<10} {'CR':>8}  {'date':<16} {'author':<22} subject")
+    flagged = 0
+    for rev in revs:
+        n = counts.get((rev, path), 0)
+        short, date, author, subject = meta.get(rev, [rev[:9], "", "", ""])
+        if n:
+            flagged += 1
+        print(f"{short:<10} {n:>8,}  {date:<16} {author[:22]:<22} {subject[:60]}"
+              f"{'  <-- CRLF' if n else ''}")
+
+    print()
+    print(f"{flagged} of {len(revs)} commits stored a CRLF blob for {path}.")
+    return 1 if flagged else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", default=".", help="repository path (default: cwd)")
+    ap.add_argument("--ref", default="origin/main", help="ref to read blobs from (default: origin/main)")
+    ap.add_argument("--history", metavar="PATH", help="forensic per-commit CR counts for ONE path")
+    ap.add_argument("--changed-since", metavar="REF",
+                    help="census only paths changed REF..--ref (the fast push-gate mode)")
+    ap.add_argument("--quiet", action="store_true", help="suppress the remediation hint")
+    args = ap.parse_args()
+
+    repo = Path(args.repo).resolve()
+    try:
+        if args.history:
+            return cmd_history(repo, args.ref, args.history)
+        if args.changed_since:
+            return cmd_changed(repo, args.ref, args.changed_since, args.quiet)
+        return cmd_census(repo, args.ref, args.quiet)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pre_push_stale_base_check.py
+++ b/scripts/pre_push_stale_base_check.py
@@ -1,0 +1,296 @@
+"""Refuse a push that deletes lines another session added upstream moments ago —
+the silent-revert class of Uprava#1516.
+
+WHY THE OBVIOUS DESIGN DOES NOT WORK
+------------------------------------
+The guard proposed on #1516 was "refuse a push whose tree contains a path modified
+upstream after the local HEAD's merge-base". Implemented and measured 04-08-2026, it
+is **redundant with git itself**: ``merge-base != remote_tip`` is the definition of a
+non-fast-forward push, which git already rejects; and a fast-forward push always has
+``merge-base == remote_tip``, so the check is vacuous exactly when it is needed. Both
+#1516 incidents were clean fast-forwards. A ref-level test cannot see them.
+
+What both incidents *do* share is visible at the line level: the push **deletes lines
+that an upstream commit added very recently**, because the author's file content was a
+pre-image copy — a stale index (29-07) or a stale checkout (04-08). Nobody edits a line
+that landed ninety seconds ago on purpose without knowing it; when it happens it is
+almost always a copy written before that line existed.
+
+THE CHECK
+---------
+For each path the push changes, take the lines it removes relative to the remote tip,
+``git blame`` them at the remote tip, and flag any whose introducing commit is
+
+* **recent** — within ``--recent-days`` (default 3), and
+* **not part of this push** — so rewriting your own just-pushed line is fine.
+
+That pair is the whole rule. Old lines are ordinary edits. Your own lines are yours.
+Someone else's line from an hour ago, deleted by a commit that never mentions it, is
+the defect.
+
+WARN BY DEFAULT — AND WHY IT WAS DEMOTED
+----------------------------------------
+This started as a **blocking** hook, which is what #1516 asked for. It was demoted to a
+warning on the day it shipped, on measured evidence: while landing its own handoff it
+refused three pushes, all of them legitimate, all of them this repo's standard workflow —
+
+1. resolving a ``CHANGELOG`` version collision by renumbering a concurrent session's
+   section (their rows deleted at the old line numbers, re-added lower);
+2. filling a ``mint_handoff.py`` stub that had been pushed to ``main`` seconds earlier;
+3. ``handoff_close.py`` archiving a handoff, which repoints ``handoffs/X`` links to
+   ``handoffs/archive/X`` **inside rows added minutes ago**.
+
+(1) and (2) are exempted below. (3) is not cleanly exemptible without special-casing the
+repo's own tooling. Three false-positive classes from routine work in one session, against
+two true incidents in a week, is the wrong ratio for a blocker: the standing response to a
+hook that refuses good pushes is to switch it off, and then it protects nothing. So the
+default is a loud warning that lets the push through, matching how the org already treats
+imperfect-judgment guards (``pre_shell_guards`` guard 9 warns on ``git pull``, because
+pulls are sometimes right)::
+
+    STALE_BASE_PUSH_STRICT=1 git push ...   # restore blocking
+    ALLOW_STALE_BASE_PUSH=1  git push ...   # silence entirely
+
+A deliberate revert of fresh upstream work is flagged too — correctly. The goal is to put
+the fact in front of a human at the last moment it is still free to act on, not to forbid.
+
+LIMITS (measured, not assumed)
+------------------------------
+* Blame is per-path and costs ~one blame per changed file; on a push touching hundreds
+  of files this is slow, so ``--max-paths`` (default 40) bounds it and the script says
+  so rather than silently sampling.
+* Pure additions are never flagged; only deletions and rewrites of recent upstream lines.
+* Whitespace-only differences are ignored (``-w``), so a CRLF renormalisation sweep does
+  not trip it — the §299/§305 class is a different problem with a different fix.
+* A push that reverts a line older than the window is not caught. That is the accepted
+  cost of keeping false positives near zero.
+
+Install once per clone::
+
+    git config core.hooksPath .githooks
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+ESCAPE_ENV = "ALLOW_STALE_BASE_PUSH"
+STRICT_ENV = "STALE_BASE_PUSH_STRICT"
+MAX_LISTED = 12
+HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+")
+
+
+def git(*args: str, check: bool = False) -> str:
+    proc = subprocess.run(
+        ("git",) + args,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if check and proc.returncode != 0:
+        raise RuntimeError("git %s failed: %s" % (" ".join(args), proc.stderr.strip()))
+    return proc.stdout
+
+
+def pushed_commits(remote_ref: str, local_ref: str) -> set[str]:
+    out = git("rev-list", "%s..%s" % (remote_ref, local_ref))
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def changed_paths(remote_ref: str, local_ref: str) -> list[str]:
+    out = git("diff", "--name-only", "-w", remote_ref, local_ref)
+    return [p for p in out.splitlines() if p.strip()]
+
+
+def removed_line_numbers(remote_ref: str, local_ref: str, path: str) -> list[int]:
+    """Line numbers AT THE REMOTE TIP that this push removes or rewrites."""
+    out = git("diff", "-w", "-U0", remote_ref, local_ref, "--", path)
+    numbers: list[int] = []
+    old_line = 0
+    for line in out.splitlines():
+        m = HUNK_RE.match(line)
+        if m:
+            old_line = int(m.group(1))
+            continue
+        if line.startswith("---") or line.startswith("+++"):
+            continue
+        if line.startswith("-"):
+            numbers.append(old_line)
+            old_line += 1
+    return numbers
+
+
+STUB_MARKER = "STUB claimed by mint_handoff.py"
+
+
+def surviving_text(local_ref: str, path: str) -> set[str]:
+    """Every non-blank stripped line of the path as this push would leave it.
+
+    Used to separate a MOVE from a LOSS. Renumbering a changelog section, resolving a
+    merge by relocating someone's rows, reordering a table — all delete lines at their
+    old position and re-add them elsewhere. The remote keeps the content, so there is
+    nothing to protect. Only a line whose text survives NOWHERE in the pushed file is a
+    real deletion. (Found by dogfooding: the guard blocked its own landing commit for
+    exactly this, which is the false-positive class that gets a blocking hook disabled.)
+    """
+    out = git("show", "%s:%s" % (local_ref, path))
+    return {ln.strip() for ln in out.splitlines() if ln.strip()}
+
+
+def is_mint_stub(remote_ref: str, path: str) -> bool:
+    """A freshly minted handoff skeleton being filled in the same pass.
+
+    `mint_handoff.py` lands a placeholder body on origin/main, then the session that
+    minted it replaces those placeholders with real content — a legitimate rewrite of
+    lines that are, by construction, minutes old and authored outside the push.
+    """
+    if "/handoffs/" not in "/" + path.replace("\\", "/"):
+        return False
+    return STUB_MARKER in git("show", "%s:%s" % (remote_ref, path))
+
+
+def blame_recent(remote_ref: str, path: str, lines: list[int],
+                 cutoff: datetime, ours: set[str],
+                 survivors: set[str]) -> list[tuple[int, str, str]]:
+    """(line, short_sha, author) for removed lines added recently by someone else."""
+    hits: list[tuple[int, str, str]] = []
+    old_text = git("show", "%s:%s" % (remote_ref, path)).splitlines()
+    for ln in lines:
+        # Moved, not lost: the same text is still somewhere in the pushed file.
+        if 1 <= ln <= len(old_text) and old_text[ln - 1].strip() in survivors:
+            continue
+        out = git("blame", "-w", "--line-porcelain", "-L", "%d,%d" % (ln, ln),
+                  remote_ref, "--", path)
+        if not out.strip():
+            continue
+        head = out.splitlines()[0].split()
+        if not head:
+            continue
+        sha = head[0]
+        if sha in ours:
+            continue
+        author = ""
+        when: datetime | None = None
+        for row in out.splitlines():
+            if row.startswith("author "):
+                author = row[len("author "):].strip()
+            elif row.startswith("author-time "):
+                try:
+                    when = datetime.fromtimestamp(int(row.split()[1]), tz=timezone.utc)
+                except (ValueError, IndexError):
+                    when = None
+        if when is not None and when >= cutoff:
+            hits.append((ln, sha[:9], author))
+    return hits
+
+
+def scan(local_ref: str, remote_ref: str, recent_days: float,
+         max_paths: int) -> tuple[dict[str, list], bool]:
+    ours = pushed_commits(remote_ref, local_ref)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=recent_days)
+    paths = changed_paths(remote_ref, local_ref)
+    truncated = len(paths) > max_paths
+
+    found: dict[str, list] = {}
+    for path in paths[:max_paths]:
+        removed = removed_line_numbers(remote_ref, local_ref, path)
+        if not removed:
+            continue
+        if is_mint_stub(remote_ref, path):
+            continue
+        hits = blame_recent(remote_ref, path, removed, cutoff, ours,
+                            surviving_text(local_ref, path))
+        if hits:
+            found[path] = hits
+    return found, truncated
+
+
+def report(found: dict[str, list], remote_ref: str, recent_days: float,
+           truncated: bool, max_paths: int) -> None:
+    total = sum(len(v) for v in found.values())
+    e = sys.stderr
+    print("", file=e)
+    print("PUSH BLOCKED — this push deletes %d line(s) that landed on %s within the"
+          % (total, remote_ref), file=e)
+    print("last %g day(s), in %d file(s), and your commits never reference them."
+          % (recent_days, len(found)), file=e)
+    print("", file=e)
+    shown = 0
+    for path, hits in found.items():
+        print("  %s" % path, file=e)
+        for ln, sha, author in hits:
+            if shown >= MAX_LISTED:
+                break
+            print("      line %-6d added by %s (%s)" % (ln, sha, author), file=e)
+            shown += 1
+        if shown >= MAX_LISTED:
+            print("      …", file=e)
+            break
+    print("", file=e)
+    print("That is Uprava#1516. Twice now a clean fast-forward with green hooks has", file=e)
+    print("installed a pre-image copy over another session's work: 6 files on 29-07", file=e)
+    print("(stale index after `git reset --soft`), 19 link fixes on 04-08 (stale", file=e)
+    print("checkout — the branch ref moved, the working tree did not).", file=e)
+    print("", file=e)
+    print("If you did NOT mean to touch those lines, your file content is stale:", file=e)
+    print("    git fetch origin && git rebase %s" % remote_ref, file=e)
+    print("and if `git status` lists files you never edited, do NOT `git add -A` and", file=e)
+    print("do NOT lift a patch out of that tree (a patch encodes its base, FINDINGS", file=e)
+    print("§308) — rebuild on a fresh worktree off %s and re-apply your edits." % remote_ref, file=e)
+    print("", file=e)
+    print("If the revert IS deliberate:  %s=1 git push ..." % ESCAPE_ENV, file=e)
+    if truncated:
+        print("", file=e)
+        print("NOTE: only the first %d changed paths were scanned (--max-paths)." % max_paths, file=e)
+    print("", file=e)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("local_ref")
+    ap.add_argument("remote_ref")
+    ap.add_argument("--recent-days", type=float, default=3.0)
+    ap.add_argument("--max-paths", type=int, default=40)
+    ap.add_argument("--no-fetch", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    if not args.no_fetch:
+        git("fetch", args.remote_ref.split("/", 1)[0] or "origin", "--quiet")
+
+    if not git("rev-parse", "--verify", "--quiet", args.remote_ref).strip():
+        if args.json:
+            print(json.dumps({"result": "skip", "reason": "remote ref not found"}))
+        return 0
+
+    found, truncated = scan(args.local_ref, args.remote_ref, args.recent_days, args.max_paths)
+
+    if args.json:
+        print(json.dumps({
+            "result": "block" if found else "ok",
+            "paths": sorted(found),
+            "lines": sum(len(v) for v in found.values()),
+            "truncated": truncated,
+        }))
+        return 1 if found else 0
+
+    if not found:
+        return 0
+    report(found, args.remote_ref, args.recent_days, truncated, args.max_paths)
+    # WARN by default; block only under STALE_BASE_PUSH_STRICT=1. See the module
+    # docstring — measured false-positive rate in this repo's own workflows is what
+    # decided this, not caution in the abstract.
+    return 1 if os.environ.get(STRICT_ENV) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Warns when a push deletes lines the remote gained in the last 3 days and the pushed commits never reference them — the shape that silently reverted 6 files on 29-07 and 19 link fixes on 04-08 in Uprava, both clean fast-forwards with green pre-commit hooks. **Advisory: it warns, it does not block** (`STALE_BASE_PUSH_STRICT=1` blocks, `ALLOW_STALE_BASE_PUSH=1` silences), because on the day it was written it refused three of its own legitimate pushes. Fails OPEN if the checker is missing. Requires `git config core.hooksPath .githooks` per clone — already set in every target. Canonical source: Uprava/scripts/pre_push_stale_base_check.py — edit there and re-run the deploy, do not fork per repo. Repos where LFS already owns pre-push get a combined hook that runs LFS first. Per cologne_batch_deploy.py (prepush-guard), H2289.

**Since H2301 the same hook also BLOCKS a push that would newly land a CRLF blob**, and `scripts/eol_census.py` ships with it — the hook fails open on a missing checker, so shipping it alone would have installed a silently inert guard. This half blocks rather than warns because a CR byte in a `text`-attributed, non-binary blob has no legitimate reading and is unfixable after the push: `git checkout` cannot repair a bad stored object, so every later session reads the file as permanently dirty and the standard remedy for that false loss-signal is DISCARD. It is a **ratchet** — a path already CRLF at the remote tip is pre-existing and ignored; only a path this push makes newly CRLF is refused. That is what makes it safe in the three repos measured dirty on 06-08-2026 (IndologyScholars 1 311 paths, csl-observatory 2, kosha 1) without handing anyone a red build for a defect they did not create. Escape hatch `ALLOW_CRLF_BLOB_PUSH=1`.