### PR TITLE
H2306: harden batch_pending durability checker

### DIFF
--- a/docs/BATCH_PENDING_DURABILITY.md
+++ b/docs/BATCH_PENDING_DURABILITY.md
@@ -1,6 +1,6 @@
 # batch_pending durability — never leave validated changefiles local-only
 
-_Created: 01-08-2026 · Last updated: 01-08-2026_
+_Created: 01-08-2026 · Last updated: 09-08-2026_
 
 **Why this exists (H2086):** agent-validated `updateByLine` changefiles for the next
 monthly csl-orig batch sit in `batch_pending/`. If they are only on one machine,
@@ -44,8 +44,15 @@ python scripts/check_batch_pending_tracked.py --list
 - Every path under `batch_pending/` (files only) is either the README or a
   changefile/readme under `dictionaries/<dict>/`.
 - No **untracked** or **modified-unstaged** pending files in the working tree.
-- Optional: warns if local `main` is ahead of `origin/main` with pending changes
-  still unpushed (when run on `main`).
+- **Fails (exit 1)** if `HEAD` is ahead of its tracking branch (resolved dynamically
+  via `@{u}`, not hardcoded `origin/main` — a `batch-pending` branch's own upstream is
+  the right comparison) with tracked `batch_pending/` content still unpushed. This was
+  a soft WARN+exit-0 before H2306; a local-only queue is exactly the durability
+  failure this check exists to catch, so it is now a hard failure, not a note.
+- The check runs `git fetch origin` first, so the comparison reflects current remote
+  state, not a stale local view of the tracking branch.
+- `--list` is unconditionally exit 0 (a dry inventory), even with a dirty working
+  tree — dirt is printed as a note on stderr, never turns `--list` into a failure.
 
 Exit **0** = durable enough for this clone. Exit **1** = agent must commit/push
 before ending the session.

--- a/scripts/check_batch_pending_tracked.py
+++ b/scripts/check_batch_pending_tracked.py
@@ -36,14 +36,32 @@ def list_pending_files() -> list[Path]:
     return sorted(p for p in PENDING.rglob("*") if p.is_file())
 
 
+def _upstream_ref() -> str:
+    """Return the tracking remote ref for the current branch (fallback: origin/main)."""
+    r = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    ref = r.stdout.strip()
+    if r.returncode == 0 and ref:
+        return ref
+    return "origin/main"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
         "--list",
         action="store_true",
-        help="print tracked/on-disk inventory and exit 0",
+        help="print tracked/on-disk inventory and exit 0 (always safe)",
     )
     args = ap.parse_args()
+
+    # Fetch so the upstream ref reflects current remote state before comparing.
+    _run(["git", "fetch", "origin", "--quiet"])
 
     on_disk = list_pending_files()
     rels = [p.relative_to(ROOT).as_posix() for p in on_disk]
@@ -65,7 +83,12 @@ def main() -> int:
         mark = "TRACKED" if r in tracked_set else "UNTRACKED"
         print(f"  [{mark}] {r}")
 
-    if args.list and not dirty_lines:
+    if args.list:
+        # --list is documented as always-exit-0; print any dirt as a note, not a failure.
+        if dirty_lines:
+            print("NOTE (list only): working-tree dirty under batch_pending", file=sys.stderr)
+            for ln in dirty_lines:
+                print(f"  {ln}", file=sys.stderr)
         print("OK (list only)")
         return 0
 
@@ -75,21 +98,22 @@ def main() -> int:
             problems.append(f"untracked (not in git index): {r}")
 
     for ln in dirty_lines:
-        # XY path — any non-space means not clean on origin's contract
         problems.append(f"working-tree dirty under batch_pending: {ln}")
 
-    # Soft warn: commits on main not pushed
-    ahead = _run(["git", "rev-list", "--count", "origin/main..HEAD"])
+    # Unpushed commits containing batch_pending work — a FAIL, not a soft warn.
+    # (H2306: was WARN+exit-0; that silently passes a local-only queue, the exact
+    # durability failure H2086 exists to prevent.)
+    upstream = _upstream_ref()
+    ahead = _run(["git", "rev-list", "--count", f"{upstream}..HEAD"])
     if ahead.returncode == 0:
         try:
             n_ahead = int((ahead.stdout or "0").strip() or "0")
         except ValueError:
             n_ahead = 0
         if n_ahead > 0 and tracked_set:
-            print(
-                f"WARN: HEAD is {n_ahead} commit(s) ahead of origin/main — "
-                f"push so batch_pending is off-machine durable",
-                file=sys.stderr,
+            problems.append(
+                f"HEAD is {n_ahead} commit(s) ahead of {upstream} — "
+                f"push so batch_pending is off-machine durable"
             )
 
     if problems:


### PR DESCRIPTION
## Summary
- `git fetch origin` before comparing so the tracking-branch check reflects current remote state
- resolve the tracking ref dynamically (`@{u}`, fallback `origin/main`) instead of hardcoding `origin/main` — needed when working on a `batch-pending` branch
- turn "ahead of upstream with pending changes" into a hard FAIL (exit 1), not a soft warn+exit-0 — a local-only queue is exactly the durability failure H2086 exists to catch
- fix `--list` to always exit 0 even when the working tree is dirty under `batch_pending/`
- update `docs/BATCH_PENDING_DURABILITY.md` "What the check proves" to match

## Test plan
- [x] `python scripts/check_batch_pending_tracked.py` — exit 0 on clean queue
- [x] `python scripts/check_batch_pending_tracked.py --list` — exit 0

Handoff: H2306 (Sonnet 5) — Reconcile /cologne-correction-queue with the H2086 durability contract